### PR TITLE
Allow to specify that you would like to use local_ipv4 instead of public_ipv4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ version.
 
 `node["monitor"]["metric_handlers"]` - Metric event handlers.
 
+`node["monitor"]["use_private_ipv4"] - Defaults to false.  If true, use local_ipv4 when available instead of public_ipv4.
+
 Usage
 =====
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,3 +2,5 @@ default["monitor"]["sensu_plugin_version"] = "0.1.4"
 
 default["monitor"]["default_handlers"] = ["debug"]
 default["monitor"]["metric_handlers"] = ["debug"]
+
+default["monitor"]["use_local_ipv4"] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,13 +18,14 @@
 #
 
 node.set.sensu.use_embedded_ruby = true
+ip_type = node["monitor"]["use_local_ipv4"] ? "local_ipv4" : "public_ipv4"
 
 unless Chef::Config[:solo]
   monitor_master = search(:node, 'recipes:monitor\:\:master').first
 
   unless monitor_master.nil?
     address = if monitor_master.has_key?("cloud")
-      monitor_master["cloud"]["public_ipv4"] || monitor_master["ipaddress"]
+      monitor_master["cloud"][ip_type] || monitor_master["ipaddress"]
     else
       monitor_master["ipaddress"]
     end
@@ -37,7 +38,7 @@ include_recipe "sensu::default"
 
 sensu_client node.name do
   if node.has_key?("cloud")
-    address node["cloud"]["public_ipv4"] || node["ipaddress"]
+    address node["cloud"][ip_type] || node["ipaddress"]
   else
     address node["ipaddress"]
   end


### PR DESCRIPTION
Added a ["monitor"]["use_local_ipv4"] attribute which defaults to false.  I have my AWS security group for my sensu server setup so that it only allows rabbitmq connections from particular security groups.  When the public IP is used it seems to be filtering all traffic regardless of origin (which makes sense).
