### PR TITLE
Adding attribute to limit search to a node's environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ version.
 
 `node["monitor"]["additional_client_attributes"]` - Additional client attributes to be passed to the sensu_client LWRP.
 
+`node["monitor"]["environment_aware_search"]` - Defaults to false.  If true, will only search for master server within the running node's chef_environment
+
 Usage
 =====
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,3 +6,5 @@ default["monitor"]["metric_handlers"] = ["debug"]
 default["monitor"]["use_local_ipv4"] = false
 
 default["monitor"]["additional_client_attributes"] = {}
+
+default["monitor"]["environment_aware_search"] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,11 @@ node.set.sensu.use_embedded_ruby = true
 ip_type = node["monitor"]["use_local_ipv4"] ? "local_ipv4" : "public_ipv4"
 
 unless Chef::Config[:solo]
-  monitor_master = search(:node, 'recipes:monitor\:\:master').first
+  monitor_master = if node["monitor"]["environment_aware_search"]
+    search(:node, "chef_environment:#{node.chef_environment} AND recipes:monitor\\:\\:master").first
+  else
+    search(:node, 'recipes:monitor\:\:master').first
+  end
 
   unless monitor_master.nil?
     address = if monitor_master.has_key?("cloud")


### PR DESCRIPTION
This is useful if you have multiple sensu servers installed in different environments.
