### PR TITLE
server_service failed to start

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -20,6 +20,12 @@
 include_recipe "sensu::rabbitmq"
 include_recipe "sensu::redis"
 
+
+service "redis" do
+  action :start
+end
+
+
 include_recipe "monitor::_worker"
 
 include_recipe "sensu::api_service"


### PR DESCRIPTION
server_service failed to start because "sensu::redis" only installed redis but does not start it. "sensu::redis" uses chef-redis repo which only installed the package
