### PR TITLE
updated README to match code: use_private_ipv4 to monitor.use_local_ipv4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The [Sensu cookbook](http://community.opscode.com/cookbooks/sensu).
 Attributes
 ==========
 
-`node["monitor"]["master_address"]` - Address to reach the sensu master server
+`node["monitor"]["master_address"]` - Bypass the chef node search and explicitly set the address to reach the sensu master server.  Setting this will overrides any search functionality.
 
 `node["monitor"]["environment_aware_search"]` - Defaults to false.
 If true, will limit search to the node's chef_environment.

--- a/README.md
+++ b/README.md
@@ -19,17 +19,19 @@ The [Sensu cookbook](http://community.opscode.com/cookbooks/sensu).
 Attributes
 ==========
 
+`node["monitor"]["master_address"]` - Address to reach the sensu master server
+
 `node["monitor"]["environment_aware_search"]` - Defaults to false.
 If true, will limit search to the node's chef_environment.
 
-`node["monitor"]["use_private_ipv4"]` - Defaults to false. If true,
+`node["monitor"]["use_local_ipv4"]` - Defaults to false. If true,
 use cloud local\_ipv4 when available instead of public\_ipv4.
-
-`node["monitor"]["additional_client_attributes"]` - Additional client
-attributes to be passed to the sensu_client LWRP.
 
 `node["monitor"]["sensu_plugin_version"]` - Sensu Plugin library
 version.
+
+`node["monitor"]["additional_client_attributes"]` - Additional client
+attributes to be passed to the sensu_client LWRP.
 
 `node["monitor"]["default_handlers"]` - Default event handlers.
 


### PR DESCRIPTION
The README.md referenced monitor.use_private_ipv4 however, the code expects monitor.use_local_ipv4

Also did some adjustment in the README to match the order in attributes/default.rb
