### PR TITLE
Data bag hints for getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Requirements
 
 The [Sensu cookbook](http://community.opscode.com/cookbooks/sensu).
 
+You'll also need a data bag for sensu_checks, since the `monitor::_worker` recipe
+does a server search for the check defines. To get started:
+
+    knife data bag create sensu_checks
+    knife data bag from file sensu_checks test/integration/data_bags/sensu_checks/ssh.jso
+
 Attributes
 ==========
 


### PR DESCRIPTION
The monitor::master recipe halts if there aren't any checks in the data bag. Since the checks are key to getting rolling, added to the README.
