### PR TITLE
Add missing line to determine ip type

### DIFF
--- a/recipes/_graphite_handler.rb
+++ b/recipes/_graphite_handler.rb
@@ -20,6 +20,8 @@
 graphite_address = node["monitor"]["graphite_address"]
 graphite_port = node["monitor"]["graphite_port"]
 
+ip_type = node["monitor"]["use_local_ipv4"] ? "local_ipv4" : "public_ipv4"
+
 case
 when Chef::Config[:solo]
   graphite_address ||= "localhost"


### PR DESCRIPTION
The `monitor::_graphite_handler` recipe miss the line to determine ip type.
I got the following error.

```
NameError
----------
Cannot find a resource for ip_type on redhat version 6.4
```
