### PR TITLE
Updating version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "portertech@gmail.com"
 license          "Apache 2.0"
 description      "A cookbook for monitoring services, using Sensu, a monitoring framework."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.4"
+version          "0.0.5"
 
 %w[
   ubuntu


### PR DESCRIPTION
Opscode version is 0.0.4, as this, but it's missing the nagios_plugins, system_profile and statsd stuff.
I think that a version upgrade is needed
