### PR TITLE
Fix "actions" filter: action is a symbol (:create) not a string ('create')

### DIFF
--- a/recipes/_filters.rb
+++ b/recipes/_filters.rb
@@ -18,7 +18,7 @@
 #
 
 sensu_filter "actions" do
-  attributes(:action => "eval: %w[create resolve].include? value")
+  attributes(:action => "eval: %w[create resolve].include? value.to_s")
 end
 
 sensu_filter "keepalives" do


### PR DESCRIPTION
One of the sample filters doesn't work with Sensu 0.12.6 because action is a symbol, not a string.  I don't know if this was due to a Sensu change or if this filter never worked; this change should fix the filter regardless.
