### PR TITLE
Remove sensu::dashboard_service, replace with uchiwa

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "portertech@gmail.com"
 license          "Apache 2.0"
 description      "A cookbook for monitoring services, using Sensu, a monitoring framework."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.4"
+version          "0.0.5"
 
 %w[
   ubuntu

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,3 +18,4 @@ end
 
 depends "sensu"
 depends "sudo"
+depends "uchiwa"

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -23,5 +23,6 @@ include_recipe "sensu::redis"
 include_recipe "monitor::_worker"
 
 include_recipe "sensu::api_service"
+include_recipe "uchiwa"
 
 include_recipe "monitor::default"

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -23,6 +23,5 @@ include_recipe "sensu::redis"
 include_recipe "monitor::_worker"
 
 include_recipe "sensu::api_service"
-include_recipe "sensu::dashboard_service"
 
 include_recipe "monitor::default"


### PR DESCRIPTION
since the newest sensu cookbook no longer has the sensu::dashboard_service recipe, it currently fails hard.

this is a quick and dirty change that replaces it with uchiwa. I haven't done much, but I did test in a vagrant and it provisioned correctly.  fixes issue #23

https://github.com/portertech/chef-monitor/issues/23
