### PR TITLE
Removing setting redis host in _master_search.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .kitchen.local.yml*
 tmp/
 vendor/
+/nbproject/private/

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,3 +19,5 @@ default["monitor"]["metric_handlers"] = ["debug"]
 
 default["monitor"]["client_extension_dir"] = "/etc/sensu/extensions/client"
 default["monitor"]["server_extension_dir"] = "/etc/sensu/extensions/server"
+
+default["monitor"]["subscriptions"] = Array.new

--- a/files/default/plugins/check-mtime.rb
+++ b/files/default/plugins/check-mtime.rb
@@ -1,61 +1,92 @@
-#!/usr/bin/env ruby
+#! /usr/bin/env ruby
 #
-# Checks a file's mtime
-# ===
+#   check-mtime
 #
 # DESCRIPTION:
 #   This plugin checks a given file's modified time.
 #
 # OUTPUT:
-#   plain-text
+#   plain text
 #
 # PLATFORMS:
-#   linux
-#   bsd
+#   Linux, BSD
 #
 # DEPENDENCIES:
-#   sensu-plugin Ruby gem
+#   gem: sensu-plugin
 #
-# Released under the same terms as Sensu (the MIT license); see LICENSE
-# for details.
+# USAGE:
+#  #YELLOW
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2014 Sonian, Inc. and contributors. <support@sensuapp.org>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'fileutils'
 
 class Mtime < Sensu::Plugin::Check::CLI
-
   option :file,
-    :description => 'File to check last modified time',
-    :short => '-f FILE',
-    :long => '--file FILE'
+         description: 'File to check last modified time',
+         short: '-f FILE',
+         long: '--file FILE'
 
-  option :warn_age,
-    :description => 'Warn if mtime greater than provided age in seconds',
-    :short => '-w SECONDS',
-    :long => '--warn SECONDS'
+  option :warning_age,
+         description: 'Warn if mtime greater than provided age in seconds',
+         short: '-w SECONDS',
+         long: '--warning SECONDS'
 
   option :critical_age,
-    :description => 'Critical if mtime greater than provided age in seconds',
-    :short => '-c SECONDS',
-    :long => '--critical SECONDS'
+         description: 'Critical if mtime greater than provided age in seconds',
+         short: '-c SECONDS',
+         long: '--critical SECONDS'
+
+  option :ok_no_exist,
+         description: 'OK if file does not exist',
+         short: '-o',
+         long: '--ok-no-exist',
+         boolean: true,
+         default: false
+
+  option :ok_zero_size,
+         description: 'OK if file has zero size',
+         short: '-z',
+         long: '--ok-zero-size',
+         boolean: true,
+         default: false
 
   def run_check(type, age)
     to_check = config["#{type}_age".to_sym].to_i
-    if(to_check > 0 && age >= to_check)
+    # #YELLOW
+    if to_check > 0 && age >= to_check # rubocop:disable GuardClause
       send(type, "file is #{age - to_check} seconds past #{type}")
     end
   end
 
   def run
     unknown 'No file specified' unless config[:file]
-    unknown 'No warn or critical age specified' unless config[:warn_age] || config[:critical_age]
-    if(File.exists?(config[:file]))
-      age = Time.now.to_i - File.mtime(config[:file]).to_i
+    unknown 'No warn or critical age specified' unless config[:warning_age] || config[:critical_age]
+    if File.exist?(config[:file])
+      if File.size?(config[:file]).nil? && !config[:ok_zero_size]
+        critical 'file has zero size'
+      end
+    end
+    f = Dir.glob(config[:file]).first
+    if f
+      if File.size?(f).nil? && !config[:ok_zero_size]
+        critical 'file has zero size'
+      end
+      age = Time.now.to_i - File.mtime(f).to_i
       run_check(:critical, age) || run_check(:warning, age) || ok("file is #{age} seconds old")
     else
-      critical 'file not found'
+      if config[:ok_no_exist]
+        ok 'file does not exist'
+      else
+        critical 'file not found'
+      end
     end
   end
-
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "portertech@gmail.com"
 license          "Apache 2.0"
 description      "A cookbook for monitoring services, using Sensu, a monitoring framework."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.6"
+version          "0.0.7"
 
 %w[
   ubuntu

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "portertech@gmail.com"
 license          "Apache 2.0"
 description      "A cookbook for monitoring services, using Sensu, a monitoring framework."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.5"
+version          "0.0.6"
 
 %w[
   ubuntu

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,12 @@
+file.reference.chef-monitor-attributes=attributes
+file.reference.chef-monitor-files=files
+file.reference.chef-monitor-recipes=recipes
+file.reference.chef-monitor-test=test
+files.dir=${file.reference.chef-monitor-files}
+javac.classpath=
+main.file=
+platform.active=Ruby
+recipes.dir=${file.reference.chef-monitor-recipes}
+source.encoding=UTF-8
+src.dir=${file.reference.chef-monitor-attributes}
+test.dir=${file.reference.chef-monitor-test}

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.ruby.rubyproject</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/ruby-project/1">
+            <name>chef-monitor</name>
+            <source-roots>
+                <root id="src.dir" name="attributes"/>
+                <root id="files.dir"/>
+                <root id="recipes.dir"/>
+                <root id="test.dir"/>
+            </source-roots>
+            <test-roots/>
+        </data>
+    </configuration>
+</project>

--- a/recipes/_master_search.rb
+++ b/recipes/_master_search.rb
@@ -45,5 +45,4 @@ when master_address.nil?
 end
 
 node.override["sensu"]["rabbitmq"]["host"] = master_address
-node.override["sensu"]["redis"]["host"] = master_address
 node.override["sensu"]["api"]["host"] = master_address

--- a/recipes/_worker.rb
+++ b/recipes/_worker.rb
@@ -53,14 +53,28 @@ else
 end
 
 check_definitions.each do |check|
-  sensu_check check["id"] do
-    type check["type"]
-    command check["command"]
-    subscribers check["subscribers"]
-    interval check["interval"]
-    handlers check["handlers"]
-    additional check["additional"]
+  if check.has_key?("checks")
+    check["checks"].each do |check_id, check_val|
+      sensu_check check_id do
+        type check_val["type"]
+        command check_val["command"]
+        subscribers check_val["subscribers"]
+        interval check_val["interval"]
+        handlers check_val["handlers"]
+        additional check_val["additional"]
+      end
+    end
+  else
+    sensu_check check["id"] do
+      type check["type"]
+      command check["command"]
+      subscribers check["subscribers"]
+      interval check["interval"]
+      handlers check["handlers"]
+      additional check["additional"]
+    end    
   end
+  
 end
 
 include_recipe "sensu::server_service"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,13 +25,20 @@ ip_type = node["monitor"]["use_local_ipv4"] ? "local_ipv4" : "public_ipv4"
 
 client_attributes = node["monitor"]["additional_client_attributes"].to_hash
 
+tag_subs = []
+if node.attribute?('tags') 
+  node['tags'].select{ |tag| tag.index('sensu_') == 0  }.each do |tag|
+    tags_subs << tag[tag.index('_') + 1..-1]
+  end
+end
+
 sensu_client node.name do
   if node.has_key?("cloud")
     address node["cloud"][ip_type] || node["ipaddress"]
   else
     address node["ipaddress"]
   end
-  subscriptions node["roles"] + ["all"]
+  subscriptions (node["roles"] + ["all"] + node['monitor']['subscriptions'] + tag_subs).uniq
   additional client_attributes
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,8 +27,8 @@ client_attributes = node["monitor"]["additional_client_attributes"].to_hash
 
 tags_subs = []
 if node.attribute?('tags') 
-  node['tags'].select{ |tag| tag.index('sensu_') == 0  }.each do |tag|
-    tags_subs << tag[tag.index('_') + 1..-1]
+  tags_subs = node['tags'].select{ |tag| tag.index('sensu_') == 0  }.map do |tag|
+    tag[tag.index('_') + 1..-1]
   end
 end
 
@@ -38,7 +38,7 @@ sensu_client node.name do
   else
     address node["ipaddress"]
   end
-  subscriptions (node["roles"] + ["all"] + node['monitor']['subscriptions'] + tags_subs).uniq
+  subscriptions (node["roles"] + ["all", Chef::Config[:node_name]] + node['monitor']['subscriptions'] + tags_subs).uniq
   additional client_attributes
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ ip_type = node["monitor"]["use_local_ipv4"] ? "local_ipv4" : "public_ipv4"
 
 client_attributes = node["monitor"]["additional_client_attributes"].to_hash
 
-tag_subs = []
+tags_subs = []
 if node.attribute?('tags') 
   node['tags'].select{ |tag| tag.index('sensu_') == 0  }.each do |tag|
     tags_subs << tag[tag.index('_') + 1..-1]
@@ -38,7 +38,7 @@ sensu_client node.name do
   else
     address node["ipaddress"]
   end
-  subscriptions (node["roles"] + ["all"] + node['monitor']['subscriptions'] + tag_subs).uniq
+  subscriptions (node["roles"] + ["all"] + node['monitor']['subscriptions'] + tags_subs).uniq
   additional client_attributes
 end
 


### PR DESCRIPTION
The redis host is only ever used by the master node and it is accessed via "localhost" by default.

This existing line breaks the configuration of the master server if redis is only bound to the loopback adapter (a secure configuration since redis is never used by any node except the master node).
